### PR TITLE
Release 0.1.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ The `SensitiveString` and `SensitiveEmail` types are straightforward string wrap
 
 `SensitiveEmail` differs from `SensitiveString` only in how it masks the original value. If you prefer having emails fully masked rather than the login part before @, use the `SensitiveString` instead.
 
+**To learn more about design decisions and how the type behaves in terms of conversions, concatenation, formatting, comparison, etc., check the architecture decision record [here](src/ADR/01.%20Behavior.md).**
+
 
 
 ## Serialization/deserialization

--- a/src/ADR/01. Behavior.md
+++ b/src/ADR/01. Behavior.md
@@ -1,0 +1,93 @@
+# 01. Behavior
+
+Date: 2025-03-01
+
+## Context
+
+The `SensitiveString` type is designed to semantically mark data that should not be exposed in logs, traces, or similar outputs. It is not an encryption mechanism but rather a way to reduce the risk of unintentional data leaks.
+
+To mitigate the risk of leaks, the underlying string is stored in a private function delegate field and only accessible through explicit method calls. Depending on configuration, serializers may include private fields in their output, but they are less likely to invoke methods to retrieve values. As a result, serialization without dedicated converters is unlikely to expose the sensitive value.
+
+At the same time, usability must be considered to prevent mistakes that could lead to debugging difficulties. In specific scenarios, revealing the underlying string is necessary. Below are the design decisions based on practical experience, which may evolve in the future.
+
+## Decision
+
+1. Implicit conversion to and from `string` is not allowed.
+2. Explicit conversion to and from `string` is supported.
+3. `ToString()` returns a masked value.
+4. `ToString(format?, IFormatProvider?)` returns a masked value by default (e.g. in string interpolation), but it can be revealed based on the format.
+5. Concatenation with `string` is supported.
+6. Concatenation with `string` returns a `string`, not `SensitiveString`.
+7. Equality comparison (`==`) is implemented for `string`.
+8. `GetHashCode()` produces different hash codes for `SensitiveString` and `string` with the same value.
+9. Derived types should declare conversion operators even if the base class already does it.
+
+## Consequences
+
+### 1. Implicit Conversion is Disabled
+
+Implicit conversion is prohibited to prevent silent data leaks. Allowing automatic conversion would make it easy to mix sensitive and non-sensitive data types without noticing, leading to inconsistencies and potential exposure.
+
+### 2. Explicit Conversion is Enabled
+
+Explicit conversion is permitted to facilitate controlled access to the underlying data. This is useful when dealing with reflection-based frameworks that attempt to convert properties into strings for database queries or validation expressions.
+
+### 3. `ToString()` Returns a Masked Value
+
+Since `ToString()` is commonly used for serialization, logging, and debugging, it should return a masked value to prevent accidental exposure.
+
+### 4. `ToString(format?, IFormatProvider?)` Returns a Masked Value
+
+String interpolation calls `ToString(format?, IFormatProvider?)` implicitly, which means returning a masked value by default can lead to confusion. However, there is no reliable way known to me to detect the object is being stringified as part of string interpolation to return the original value then. Therefore, the value has to be revealed explicitly.
+
+```c#
+SensitiveString sensitive = "abcd".AsSensitive();
+Console.WriteLine(sensitive); // Outputs: ***"
+Console.WriteLine(sensitive.ToString()); // Outputs: "***"
+Console.WriteLine($"{sensitive}"); // Outputs: ***"
+Console.WriteLine($"{sensitive:R}"); // Outputs: abcd"
+Console.WriteLine($"{sensitive.Reveal()}"); // Outputs: abcd"
+```
+
+### 5. Concatenation with `string` is Supported
+
+To enhance usability, concatenation with `string` is allowed. This is particularly useful in LINQ queries where filtering might require string operations.
+
+```c#
+SensitiveString sensitive = "abcd".AsSensitive();
+string message = "Your token is " + sensitive;
+Console.WriteLine(message); // Outputs: "Your token is abcd"
+```
+
+### 6. Concatenation Produces `string`, Not `SensitiveString`
+
+Despite the sensitivity of the data, concatenating `SensitiveString` with a `string` produces a `string`. This prevents issues in frameworks like Entity Framework Core, which might not support filtering operations involving concatenation of custom types.
+
+### 7. Equality Comparison with `string` is Allowed
+
+To improve usability, direct equality checks between `SensitiveString` and `string` are supported. However, developers should be cautious about unintended type mixing.
+
+```c#
+SensitiveString sensitive = "abcd".AsSensitive();
+bool isEqual = sensitive == "abcd";
+Console.WriteLine(isEqual); // Outputs: True
+```
+
+### 8. Hash Codes Differ Between `SensitiveString` and `string`
+
+The hash code for a `SensitiveString` differs from that of a `string` containing the same value. This ensures that objects of different types are not treated as identical when stored in hash-based collections.
+
+```
+var input = "abcd";
+var sensitive = input.AsSensitive();
+var isEqual = input.GetHashCode() == sensitive.GetHashCode();
+Console.WriteLine(isEqual); // Outputs: False
+```
+
+### 9. Derived Types Should Explicitly Declare Conversion Operators
+
+Derived types (e.g., `SensitiveEmail`) should explicitly declare a conversion operator to `string` even though the base class (`SensitiveString`) already does it. Otherwise, reflection-based conversion on those types may fail (consider validators or ORMs for example).
+
+### Summary
+
+The `SensitiveString` type is designed to prevent accidental data leaks while maintaining usability. The chosen design ensures that developers must explicitly reveal sensitive data, preventing implicit leaks via logging, serialization, or unintended conversions. At the same time, explicit conversions and equality comparisons allow for practical use cases without excessive friction.

--- a/src/TextPrivacy.SensitiveString/SensitiveEmail.cs
+++ b/src/TextPrivacy.SensitiveString/SensitiveEmail.cs
@@ -8,6 +8,15 @@ namespace TextPrivacy.SensitiveString;
 /// </summary>
 public class SensitiveEmail : SensitiveString
 {
+    /// <summary>
+    ///     Creates a new sensitive email instance.
+    /// </summary>
+    /// <param name="value">
+    ///     The input string to protect.
+    /// </param>
+    /// <exception cref="ArgumentNullException">
+    ///     Thrown when the input string is null.
+    /// </exception>
     private SensitiveEmail(string value)
         : base(value)
     {

--- a/src/TextPrivacy.SensitiveString/SensitiveString.Concatenation.cs
+++ b/src/TextPrivacy.SensitiveString/SensitiveString.Concatenation.cs
@@ -5,8 +5,8 @@ public partial class SensitiveString
 {
     public static SensitiveString operator +(SensitiveString? left, SensitiveString? right) => new(left?._getValue() + right?._getValue());
 
-    public static SensitiveString operator +(SensitiveString? left, string? right) => new(left?._getValue() + right);
-    public static SensitiveString operator +(string? left, SensitiveString? right) => new(left + right?._getValue());
+    public static string operator +(SensitiveString? left, string? right) => left?._getValue() + right;
+    public static string operator +(string? left, SensitiveString? right) => left + right?._getValue();
 
     public static SensitiveString operator +(SensitiveString? left, object? right) => new(left?._getValue() + right);
     public static SensitiveString operator +(object? left, SensitiveString? right) => new(left + right?._getValue());

--- a/src/TextPrivacy.SensitiveString/SensitiveString.Formattable.cs
+++ b/src/TextPrivacy.SensitiveString/SensitiveString.Formattable.cs
@@ -4,16 +4,19 @@ public partial class SensitiveString : IFormattable
 {
     /// <summary>
     ///     Returns a string representation of the value with optional formatting.
-    ///     The following formats are supported:
+    ///     The following formats are supported (case-insensitive):
     ///     <list type="bullet">
     ///         <item>
     ///             <description><c>R</c> – Reveals the original value.</description>
     ///         </item>
     ///         <item>
-    ///             <description><c>M:</c> – Applies a custom mask instead of the default one, e.g. <c>M:*****</c>.</description>
+    ///             <description><c>M</c> or <c>null</c> – Masks the value with the default mask.</description>
+    ///         </item>
+    ///         <item>
+    ///             <description><c>M:</c> – Applies a custom mask instead of the default one, e.g. <c>M:*</c> will return <c>*</c>.</description>
     ///         </item>
     ///     </list>
-    ///     If the format is not recognized, the default masking is applied, and the value remains hidden.
+    ///     If the format is not recognized, an exception is thrown.
     /// </summary>
     /// <param name="format">
     ///     The format specifier.
@@ -21,16 +24,17 @@ public partial class SensitiveString : IFormattable
     /// <param name="formatProvider">
     ///     A format provider (currently unused).
     /// </param>
-    public string ToString(string? format, IFormatProvider? formatProvider)
+    /// <exception cref="FormatException">
+    ///     Thrown when the format is not recognized.
+    /// </exception>
+    public string ToString(string? format, IFormatProvider? formatProvider = null)
     {
         return format?.ToLowerInvariant() switch
         {
             "r" => _getValue(), // revealed
             ['m', ':', .. var mask] => mask, // return the specified mask
-            _ => ToString() // default masking
+            "m" or null => ToString(), // default masking
+            _ => throw new FormatException($"The format '{format}' is not supported.")
         };
     }
-
-    /// <inheritdoc cref="ToString(string?,System.IFormatProvider?)" />
-    public string ToString(string? format) => ToString(format, formatProvider: null);
 }

--- a/src/TextPrivacy.SensitiveString/SensitiveString.cs
+++ b/src/TextPrivacy.SensitiveString/SensitiveString.cs
@@ -27,7 +27,7 @@ public partial class SensitiveString
     /// <exception cref="ArgumentNullException">
     ///     Thrown when the input string is null.
     /// </exception>
-    protected SensitiveString(string value)
+    protected internal SensitiveString(string value)
     {
         if (value is null)
         {

--- a/src/TextPrivacy.SensitiveString/TextPrivacy.SensitiveString.csproj
+++ b/src/TextPrivacy.SensitiveString/TextPrivacy.SensitiveString.csproj
@@ -18,7 +18,7 @@
 
         <Deterministic>true</Deterministic>
 
-        <Version>0.1.7</Version>
+        <Version>0.1.8</Version>
         <IncludeSourceRevisionInInformationalVersion>true</IncludeSourceRevisionInInformationalVersion>
 
         <PackageId>SensitiveString</PackageId>
@@ -53,6 +53,10 @@ See also https://github.com/$(Repository)/releases</PackageReleaseNotes>
         <Optimize>true</Optimize>
     </PropertyGroup>
 
+    <ItemGroup Condition="'$(Configuration)' != 'Publish'">
+        <InternalsVisibleTo Include="TextPrivacy.SensitiveString.Tests" />
+    </ItemGroup>
+    
     <PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">
         <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
     </PropertyGroup>

--- a/test/TextPrivacy.SensitiveString.Tests/SensitiveStringConcatenationTest.cs
+++ b/test/TextPrivacy.SensitiveString.Tests/SensitiveStringConcatenationTest.cs
@@ -36,24 +36,24 @@ public class SensitiveStringConcatenationTest
         var s2 = "hello2";
 
         var concat = s1 + s2;
-        Assert.Equal("hello1hello2", concat.Reveal());
+        Assert.Equal("hello1hello2", concat);
 
         concat = s2 + s1;
-        Assert.Equal("hello2hello1", concat.Reveal());
+        Assert.Equal("hello2hello1", concat);
 
         s1 = null;
         concat = s1 + s2;
-        Assert.Equal("hello2", concat.Reveal());
+        Assert.Equal("hello2", concat);
 
         concat = s2 + s1;
-        Assert.Equal("hello2", concat.Reveal());
+        Assert.Equal("hello2", concat);
 
         s2 = null;
         concat = s1 + s2;
-        Assert.Empty(concat.Reveal());
+        Assert.Empty(concat);
 
         concat = s2 + s1;
-        Assert.Empty(concat.Reveal());
+        Assert.Empty(concat);
     }
 
     [Fact]

--- a/test/TextPrivacy.SensitiveString.Tests/SensitiveStringFormattableTest.cs
+++ b/test/TextPrivacy.SensitiveString.Tests/SensitiveStringFormattableTest.cs
@@ -7,10 +7,14 @@ public class SensitiveStringFormattableTest
     {
         var ss = "hello".AsSensitive();
 
+        Assert.Equal("***", $"{ss}");
+        Assert.Equal(ss.ToString(), $"{ss}");
         Assert.Equal(ss.Reveal(), $"{ss:R}");
         Assert.Equal(ss.Reveal(), $"{ss:r}");
-        Assert.Equal(ss.ToString(), $"{ss}");
-        Assert.Equal(ss.ToString(), $"{ss:xxx}");
+
+        Assert.Throws<FormatException>(() => $"{ss:xyz}");
+        Assert.Throws<FormatException>(() => $"{ss:rxyz}");
+        Assert.Throws<FormatException>(() => $"{ss:mxyz}");
     }
 
     [Fact]
@@ -23,6 +27,7 @@ public class SensitiveStringFormattableTest
         Assert.Equal(mask, $"{ss:M:*masked*}");
         Assert.Equal(mask, $"{ss:m:*masked*}");
         Assert.Equal("", $"{ss:m:}");
+        Assert.Equal(ss.ToString(), $"{ss:m}");
         Assert.Equal(mask, ss.ToString($"M:{mask}"));
         Assert.Equal(mask, email.ToString($"M:{mask}"));
     }

--- a/test/TextPrivacy.SensitiveString.Tests/SensitiveStringTest.cs
+++ b/test/TextPrivacy.SensitiveString.Tests/SensitiveStringTest.cs
@@ -1,5 +1,3 @@
-using System.Reflection;
-
 namespace TextPrivacy.SensitiveString.Tests;
 
 public class SensitiveStringTest
@@ -32,25 +30,8 @@ public class SensitiveStringTest
     [Fact]
     public void constructor_input_value_cannot_be_null()
     {
-        var input = default(string);
-        Assert.Throws<ArgumentNullException>(() =>
-            {
-                try
-                {
-                    Activator.CreateInstance(
-                        type: typeof(SensitiveString),
-                        bindingAttr: BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.CreateInstance,
-                        binder: null,
-                        args: [input],
-                        culture: null
-                    );
-                }
-                catch (TargetInvocationException e)
-                {
-                    throw e.InnerException!;
-                }
-            }
-        );
+        var input = default(string)!;
+        Assert.Throws<ArgumentNullException>(() => new SensitiveString(input));
     }
 
     [Fact]


### PR DESCRIPTION
The reason behind it is that Entity Framework Core throws an exception when SensitiveString is a result of concatenation.